### PR TITLE
Improve numerical stability of projection

### DIFF
--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -15,8 +15,8 @@ void main() {
   vec3 vertexPosition = mix(coordinates[0],
     mix(coordinates[2], coordinates[1], 0.5 * (position + 1.0)), abs(position));
 
-  vec4 clipPos = projection * view * model * vec4(vertexPosition, 1.0);
-  vec2 clipOffset = (projection * view * model * vec4(color, 0.0)).xy;
+  vec4 clipPos = projection * (view * (model * vec4(vertexPosition, 1.0)));
+  vec2 clipOffset = (projection * (view * (model * vec4(color, 0.0)))).xy;
   vec2 delta = weight * clipOffset * screenShape;
   vec2 lineOffset = normalize(vec2(delta.y, -delta.x)) / screenShape;
 


### PR DESCRIPTION
When the position vector has large values that are cancelled out by large values in the model matrix, it is more numerically stable to first multiply the position by the model matrix instead of multiplying the matrices together first.

This should always yield equivalent or more accurate results.

Helps with https://github.com/plotly/plotly.js/issues/3306
See https://github.com/gl-vis/gl-axes3d/pull/23